### PR TITLE
Secured login after email confirmation

### DIFF
--- a/src/controllers/SiteController.php
+++ b/src/controllers/SiteController.php
@@ -492,6 +492,7 @@ class SiteController extends \hisite\controllers\SiteController
                     ['email' => $user->email_confirmed ?? $user->email]
                 )
             );
+            Yii::$app->session->set(ConfirmEmail::SESSION_VAR_NAME, $user->email);
         } else {
             Yii::error('Failed to send email confirmation letter', __METHOD__);
         }

--- a/tests/_support/Helper/TokenHelper.php
+++ b/tests/_support/Helper/TokenHelper.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace hiam\tests\_support\Helper;
+
+
+use hiam\tests\_support\AcceptanceTester;
+use Yii;
+
+/**
+ * Class TokenHelper
+ * @package hiam\tests\_support\Helper
+ */
+final class TokenHelper
+{
+    /**
+     * @return string|null
+     */
+    public static function findLastToken(): ?string
+    {
+        $tokensDir = static::getTokensDir();
+
+        foreach (range(1, 31) as $try) {
+            codecept_debug("$try try to get Token by path: $tokensDir");
+            sleep(2);
+            $res = exec("find $tokensDir -type f -cmin -1 -exec basename {} \; | tail -1");
+
+            if ($res) {
+                return $res;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public static function getTokensDir()
+    {
+        return Yii::getAlias('@runtime/tokens');
+    }
+
+    /**
+     * @param AcceptanceTester $I
+     * @return string
+     */
+    public static function getTokenUrl(AcceptanceTester $I): string
+    {
+        $message = $I->getLastMessage();
+        $I->assertNotEmpty($message, 'make sure that the mail received');
+        $resetTokenLink = $I->getResetTokenUrl($message);
+        $I->assertNotEmpty($resetTokenLink, 'make sure that reset token link received');
+
+        return $resetTokenLink;
+    }
+}

--- a/tests/_support/Page/AbstractHiamPage.php
+++ b/tests/_support/Page/AbstractHiamPage.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class AbstractHiamPage
+ * @package hiam\tests\_support\Page
+ */
+abstract class AbstractHiamPage
+{
+    /**
+     * @var AcceptanceTester
+     */
+    protected $tester;
+
+    /**
+     * AbstractHiamPage constructor.
+     * @param AcceptanceTester $I
+     */
+    public function __construct(AcceptanceTester $I)
+    {
+        $this->tester = $I;
+    }
+
+    /**
+     * @param array $info
+     * @throws \Exception
+     */
+    abstract public function tryFillContactInfo(array $info): void;
+
+    /**
+     * @throws \Exception
+     */
+    public function tryClickSubmitButton(): void
+    {
+        $this->tester->clickWithLeftButton(['css' => 'button[type=submit]']);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function tryLogout(): void
+    {
+        $this->tester->click('a[href="/site/logout"]');
+    }
+}

--- a/tests/_support/Page/ChangeEmail.php
+++ b/tests/_support/Page/ChangeEmail.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class ChangeEmail
+ * @package hiam\tests\_support\Page
+ */
+class ChangeEmail extends AbstractHiamPage
+{
+    /**
+     * ChangePassword constructor.
+     * @param AcceptanceTester $I
+     */
+    public function __construct(AcceptanceTester $I)
+    {
+        parent::__construct($I);
+        $I->amOnPage('/site/change-email');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tryFillContactInfo(array $info): void
+    {
+
+    }
+}

--- a/tests/_support/Page/ChangePassword.php
+++ b/tests/_support/Page/ChangePassword.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class ChangePassword
+ * @package hiam\tests\_support\Page
+ */
+class ChangePassword extends AbstractHiamPage
+{
+    /**
+     * ChangePassword constructor.
+     * @param AcceptanceTester $I
+     */
+    public function __construct(AcceptanceTester $I)
+    {
+        parent::__construct($I);
+        $I->amOnPage('/site/change-password');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tryFillContactInfo(array $info): void
+    {
+
+    }
+}

--- a/tests/_support/Page/Lockscreen.php
+++ b/tests/_support/Page/Lockscreen.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class LockscreenPage
+ * @package hiam\tests\_support\Page
+ */
+class Lockscreen extends AbstractHiamPage
+{
+    /**
+     * LockscreenPage constructor.
+     * @param AcceptanceTester $I
+     */
+    public function __construct(AcceptanceTester $I)
+    {
+        parent::__construct($I);
+        $I->amOnPage('/site/lockscreen');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tryFillContactInfo(array $info): void
+    {
+    }
+}

--- a/tests/_support/Page/Login.php
+++ b/tests/_support/Page/Login.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class Login
+ * @package hiam\tests\_support\Page
+ */
+class Login extends AbstractHiamPage
+{
+    /**
+     * SignUp constructor.
+     * @param AcceptanceTester $I
+     */
+    public function __construct(AcceptanceTester $I)
+    {
+        parent::__construct($I);
+        $I->amOnPage('/site/login');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tryFillContactInfo(array $info): void
+    {
+        $I = $this->tester;
+        $I->fillField(['name' => 'LoginForm[username]'], $info['username']);
+        $I->fillField(['name' => 'LoginForm[password]'], $info['password']);
+    }
+}

--- a/tests/_support/Page/ResetPassword.php
+++ b/tests/_support/Page/ResetPassword.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class ResetPassword
+ * @package hiam\tests\_support\Page
+ */
+class ResetPassword extends AbstractHiamPage
+{
+    /**
+     * ResetPassword constructor.
+     * @param AcceptanceTester $I
+     * @param string $tokenUrl
+     */
+    public function __construct(AcceptanceTester $I, string $tokenUrl)
+    {
+        parent::__construct($I);
+        $I->amOnUrl($tokenUrl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tryFillContactInfo(array $info): void
+    {
+        $this->tester->fillField(['name' => 'ResetPasswordForm[password]'], $info['password']);
+        $this->tester->fillField(['name' => 'ResetPasswordForm[password_retype]'], $info['password']);
+    }
+}

--- a/tests/_support/Page/RestorePassword.php
+++ b/tests/_support/Page/RestorePassword.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace hiam\tests\_support\Page;
+
+
+use hiam\tests\_support\AcceptanceTester;
+
+/**
+ * Class RestorePassword
+ * @package hiam\tests\_support\Page
+ */
+class RestorePassword extends AbstractHiamPage
+{
+    /**
+     * RestorePassword constructor.
+     * @param AcceptanceTester $I
+     */
+    public function __construct(AcceptanceTester $I)
+    {
+        parent::__construct($I);
+        $I->amOnPage('/site/restore-password');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tryFillContactInfo(array $info): void
+    {
+        $this->tester->fillField(['name' => 'RestorePasswordForm[username]'], $info['username']);
+    }
+}

--- a/tests/_support/Page/SignUp.php
+++ b/tests/_support/Page/SignUp.php
@@ -4,19 +4,24 @@ namespace hiam\tests\_support\Page;
 
 use hiam\tests\_support\AcceptanceTester;
 
-class SignUp
+/**
+ * Class SignUp
+ * @package hiam\tests\_support\Page
+ */
+class SignUp extends AbstractHiamPage
 {
-    /** @var AcceptanceTester */
-    private $tester;
-
+    /**
+     * SignUp constructor.
+     * @param AcceptanceTester $I
+     */
     public function __construct(AcceptanceTester $I)
     {
-        $this->tester = $I;
+        parent::__construct($I);
+        $I->amOnPage('/site/signup');
     }
 
     /**
-     * @param array
-     * @throws \Exception
+     * @inheritDoc
      */
     public function tryFillContactInfo(array $info): void
     {

--- a/tests/acceptance/ConfirmEmailCest.php
+++ b/tests/acceptance/ConfirmEmailCest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace hiam\tests\acceptance;
+
+use hiam\tests\_support\AcceptanceTester;
+use hiam\tests\_support\Helper\TokenHelper;
+use hiam\tests\_support\Page\Lockscreen;
+use hiam\tests\_support\Page\SignUp;
+
+class ConfirmEmailCest
+{
+    /**
+     * @param AcceptanceTester $I
+     * @throws \Exception
+     */
+    public function checkEmailConfirm(AcceptanceTester $I): void
+    {
+        $I->wantTo('check email confirm');
+        [$user,] = $this->getUsersInfo();
+
+        $this->doSignupActions($I, $user);
+        $this->doEmailConfirmCheck($I, $user);
+        $I->see($user['username']);
+    }
+
+    /**
+     * @param AcceptanceTester $I
+     * @throws \Exception
+     */
+    public function checkEmailConfirmAfterLogout(AcceptanceTester $I): void
+    {
+        $I->wantTo('check email confirm after logout');
+        [$user,] = $this->getUsersInfo();
+
+        $this->doSignupActions($I, $user);
+        $this->doLogout($I);
+        $this->doEmailConfirmCheck($I, $user);
+        $I->see('Sign in to Advanced Hosting');
+    }
+
+    /**
+     * @param AcceptanceTester $I
+     * @throws \Exception
+     */
+    public function checkEmailConfirmWhenAnotherUserIsLoggedIn(AcceptanceTester $I): void
+    {
+        $I->wantTo('check email confirm when another user is logged in');
+        [$user1, $user2] = $this->getUsersInfo();
+
+        $this->doSignupActions($I, $user1);
+        $this->doLogout($I);
+        $this->doSignupActions($I, $user2);
+        $this->doEmailConfirmCheck($I, $user1);
+        $I->waitForText($user2['username']);
+    }
+
+    /**
+     * @param AcceptanceTester $I
+     * @param array $user
+     * @throws \Exception
+     */
+    private function doSignupActions(AcceptanceTester $I, array $user): void
+    {
+        $signupPage = new SignUp($I);
+        $signupPage->tryFillContactInfo($user);
+        $signupPage->tryClickAdditionalCheckboxes();
+        $signupPage->tryClickAgreeTermsPrivacy();
+        $signupPage->tryClickSubmitButton();
+        $I->waitForText($user['username']);
+    }
+
+    /**
+     * @param AcceptanceTester $I
+     * @param array $user
+     */
+    private function doEmailConfirmCheck(AcceptanceTester $I, array $user): void
+    {
+        $token = TokenHelper::findLastToken();
+        $I->assertNotEmpty($token, 'token exists');
+        $I->amOnPage('/site/confirm-sign-up-email?token=' . $token);
+    }
+
+    private function doLogout(AcceptanceTester $I): void
+    {
+        $lockscreenPage = new Lockscreen($I);
+        $lockscreenPage->tryLogout();
+    }
+
+    /**
+     * @return array
+     */
+    private function getUsersInfo(): array
+    {
+        return [
+            [
+                'username' => uniqid() . 'test@test.test',
+                'password' => 'password',
+            ],
+            [
+                'username' => uniqid() . 'test1@test1.test1',
+                'password' => 'password1',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Disallow login with a stolen token.
Saving `confirming_email` value to user session.
Login user only when confirmed email matches to `confirming_email`.
Also, it denies login of the same user from another browser.